### PR TITLE
2つの配列の順番が異なっていたので、followingByListに全部の情報を集めた

### DIFF
--- a/src/views/Mypage.vue
+++ b/src/views/Mypage.vue
@@ -32,9 +32,9 @@
             v-if="followingByIdList[index]"
             :to="{
               name: 'Others',
-              params: { id: followingByIdList[index] },
+              params: { id: followingByList[index].id },
             }"
-            >{{ following }}</router-link
+            >{{ following.name }}</router-link
           >
         </div>
       </div>
@@ -45,8 +45,8 @@
         <h1>
           {{ userName }}
 
-        {{followingByIdList}}
-        {{followingByList}}
+          {{ followingByIdList }}
+          {{ followingByList }}
         </h1>
         <div v-if="isSignedIn">
           <!-- <img
@@ -261,7 +261,10 @@ export default {
             .then((querySnapshot) => {
               let followingBy = ""
               querySnapshot.forEach((doc) => {
-                followingBy = doc.data().name
+                followingBy = {
+                  name: doc.data().name,
+                  id: followingByIdList[i],
+                }
               })
               this.followingByList.push(followingBy)
               // this.followingByList[i] = followingBy


### PR DESCRIPTION
### **【まとめ】**
フォロワーのリンクからうまく飛べないという問題点があり、調べてみると、以下の二つの配列の格納されているデータの順番が異なっていた。

- `followingByList`
- `followingByIdList`

▶ `followingByList` にユーザーのid情報を保存し、描画は全て`followingByList` を元にして行えば良さそう。

### **【検討したこと】**
`followingByList` と `followingByIdList` のデータの順番が異なるのは、 for 文が then を待ってくれないためだと思われる。

thenを待ってもらうように実装することも検討したが、フォロワーの数が増えたときに処理に時間がかかると考えられるため、今回は採用しなかった。（ちなみに、最初はその方向性しか見えていなかった。時間を置くのは大事だ🤔）

### **【確認方法】**

- [ ] コードを確認する。多分そこまで難しい変更ではないと思うから、かけるなら理解できるはず。
- [ ] fix_followerListブランチに移動し、`git fetch`⇒ `git merge` して、ローカルで動作を確認する。
- [ ] 問題なく動作しているなら、このpull requestをマージする
